### PR TITLE
Fix respawn statistic typo

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -334,7 +334,7 @@ function setupEventListeners() {
     document.getElementById('zen-loss-replay').addEventListener('click', function() {
         Audio.playSound('click-sound');
         UI.hideZenLossModal();
-        Statistics.markZenRespawUsed(); // Mark that a respawn was used
+        Statistics.markZenRespawnUsed(); // Mark that a respawn was used
         // Replay the current level (which is stored in State.zenLevel)
         UI.startZenLevel(State.zenLevel);
     });

--- a/js/statistics.js
+++ b/js/statistics.js
@@ -381,7 +381,7 @@ export function getStreakInfo() {
 /**
  * Marks that a respawn was used in the current Zen run.
  */
-export function markZenRespawUsed() {
+export function markZenRespawnUsed() {
     const stats = loadStatistics();
     if (stats.zenProgress.currentRun) {
         stats.zenProgress.currentRun.usedRespawns = true;


### PR DESCRIPTION
## Summary
- correct function name typo `markZenRespawnUsed`
- update call sites in main script

## Testing
- `node --check js/statistics.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_684011dcf0c8833282c13ac0dea1d673