### PR TITLE
Fix typo in TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -103,7 +103,7 @@ Implemented calming background audio options (forest, rain, ocean)
 - [ ] **Mobile Support**
   - Responsive design for mobile screens
   - Touch controls optimization
-  - Pinch to zoom on larger boardsI
+  - Pinch to zoom on larger boards
 
 - [X] **Performance Optimizations**
   - Improve rendering for very large custom boards


### PR DESCRIPTION
## Summary
- fix typo in TODO.md within the Mobile Support section

## Testing
- `grep -n "Pinch to zoom" -n TODO.md`


------
https://chatgpt.com/codex/tasks/task_e_6840130f411c8332a08c59f93d7ae038