### PR TITLE
Fix tutorial re-show logic

### DIFF
--- a/js/tutorial.js
+++ b/js/tutorial.js
@@ -228,7 +228,7 @@ function checkIfShowTutorial() {
     // Get statistics directly from localStorage to check if games have been played
     let hasPlayedGames = false;
     try {
-        const stats = JSON.parse(localStorage.getItem('statistics'));
+        const stats = JSON.parse(localStorage.getItem('gameStatistics'));
         hasPlayedGames = stats && stats.games && stats.games.played > 0;
     } catch (e) {
         console.log('No valid statistics found in localStorage');


### PR DESCRIPTION
## Summary
- look up stats under `gameStatistics` when deciding to auto show tutorial

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840130ecfb0833283f7c51a3d616d5d