### PR TITLE
Add Jest setup and statistics tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Demineur
+
+This project is a relaxing Minesweeper clone. Tests are written with [Jest](https://jestjs.io/).
+
+## Running Tests
+
+Install dependencies once:
+
+```bash
+npm install
+```
+
+Execute the test suite:
+
+```bash
+npm test
+```
+
+This runs Jest and reports the results for all files in the `tests/` directory.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "demineur",
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "transform": {}
+  }
+}

--- a/tests/statistics.test.js
+++ b/tests/statistics.test.js
@@ -1,0 +1,22 @@
+import { loadStatistics, markZenRespawnUsed, resetStatistics } from '../js/statistics.js';
+
+describe('Statistics utilities', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetStatistics();
+  });
+
+  test('loadStatistics returns defaults when localStorage is empty', () => {
+    const stats = loadStatistics();
+    expect(stats.games.played).toBe(0);
+    expect(stats.games.won).toBe(0);
+    expect(stats.zenProgress.currentRun.level).toBe(1);
+    expect(stats.zenProgress.currentRun.usedRespawns).toBe(false);
+  });
+
+  test('markZenRespawnUsed sets flag in current run', () => {
+    markZenRespawnUsed();
+    const stats = loadStatistics();
+    expect(stats.zenProgress.currentRun.usedRespawns).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- initialize `package.json` with Jest using jsdom environment
- add tests for statistics functions
- document running tests in a new README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840130c795c8332b4206546d142aa54