### PR TITLE
Fix custom game size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This project is a relaxing Minesweeper clone. Tests are written with [Jest](https://jestjs.io/).
 
+## Custom Boards
+
+You can create custom games with dimensions from 5x5 up to 500x500 cells via the
+"Custom" button on the main menu. Mine counts are limited to 30% of the total
+tiles.
+
 ## Running Tests
 
 Install dependencies once:

--- a/js/ui.js
+++ b/js/ui.js
@@ -126,8 +126,8 @@ export function startCustomGame() {
     const heightInput = document.getElementById('height');
     const minesInput = document.getElementById('mines');
     
-    const rows = Math.max(5, Math.min(100, parseInt(heightInput.value) || 10));
-    const columns = Math.max(5, Math.min(100, parseInt(widthInput.value) || 10));
+    const rows = Math.max(5, Math.min(500, parseInt(heightInput.value) || 10));
+    const columns = Math.max(5, Math.min(500, parseInt(widthInput.value) || 10));
     
     // Calculate maximum mines allowed (30% of total tiles)
     const totalTiles = rows * columns;


### PR DESCRIPTION
## Summary
- allow custom boards up to 500x500 in `startCustomGame`
- document custom board limits in README

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6840156bc5288332b461f0a42eda3f1d