### PR TITLE
Preserve safe-mode preference around Zen games

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -18,6 +18,8 @@ export let timerInterval;
 export let flaggedMines = 0;
 export let speedrunMode = true;
 export let safeMode = false; // Prevent 50/50 chance situations
+// Store the user's preference before Zen Mode overrides it
+export let previousSafeMode = false;
 export let difficulty = 'easy'; // Track current difficulty
 export let isZenMode = false; // Track if Zen Mode is active
 export let zenLevel = 1; // Track current Zen Mode level
@@ -37,6 +39,10 @@ export function setSpeedrunMode(value) {
 
 export function setSafeMode(value) {
     safeMode = value;
+}
+
+export function setPreviousSafeMode(value) {
+    previousSafeMode = value;
 }
 
 export function incrementCellsRevealed() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -312,11 +312,19 @@ export function resetToMainScreen() {
         import('./statistics.js').then(Statistics => {
             Statistics.resetZenRun();
         });
+
+        // Restore the user's previous safe mode preference
+        State.setSafeMode(State.previousSafeMode);
+        const safeToggle = document.getElementById('safe-mode-toggle');
+        if (safeToggle) {
+            safeToggle.checked = State.safeMode;
+        }
     }
-    
+
     // Update difficulty indicator back to normal and hide Zen indicator
     updateDifficultyIndicator();
     updateZenLevelIndicator();
+    updateModeIndicators();
 }
 
 /**
@@ -594,6 +602,11 @@ function getZenLevelConfig(level) {
  * @param {number} level - The level to start.
  */
 export function startZenLevel(level) {
+    // If we're entering Zen Mode for the first time, remember the current safe mode setting
+    if (!State.isZenMode) {
+        State.setPreviousSafeMode(State.safeMode);
+    }
+
     // Set Zen Mode state
     State.setZenMode(true);
     State.setZenLevel(level);
@@ -604,6 +617,10 @@ export function startZenLevel(level) {
 
     // Ensure Safe Mode is enabled for Zen Mode
     State.setSafeMode(true);
+    const safeToggle = document.getElementById('safe-mode-toggle');
+    if (safeToggle) {
+        safeToggle.checked = true;
+    }
     
     // Update the Zen level indicator BEFORE initializing the game
     updateZenLevelIndicator();

--- a/tests/zenSafeMode.test.js
+++ b/tests/zenSafeMode.test.js
@@ -1,0 +1,61 @@
+import { jest } from '@jest/globals';
+
+let State;
+let UI;
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <div class="game-board-container"><div id="game-board"></div></div>
+    <div id="main-screen"></div>
+    <div id="in-game-ui"></div>
+    <div id="zen-level-indicator"><span id="zen-current-level"></span></div>
+    <div id="game-title"></div>
+    <input type="checkbox" id="safe-mode-toggle" />
+    <div id="new-game-in-game"></div>
+    <div id="current-difficulty-label"></div>
+    <div id="mines-counter"></div>
+    <div id="timer"></div>
+    <div id="speedrun-indicator" class="mode-indicator"></div>
+    <div id="safe-indicator" class="mode-indicator"></div>
+    <div id="in-game-speedrun" class="in-game-mode-indicator"></div>
+    <div id="in-game-safe" class="in-game-mode-indicator"></div>
+  `;
+}
+
+beforeEach(async () => {
+  jest.useFakeTimers();
+  jest.resetModules();
+  setupDOM();
+  State = await import('../js/state.js');
+  UI = await import('../js/ui.js');
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+test('safe mode restored after exiting Zen mode when initially off', () => {
+  State.setSafeMode(false);
+  UI.startZenLevel(1);
+  jest.runAllTimers();
+  expect(State.safeMode).toBe(true);
+  expect(State.previousSafeMode).toBe(false);
+  expect(document.getElementById('safe-mode-toggle').checked).toBe(true);
+
+  UI.resetToMainScreen();
+  expect(State.safeMode).toBe(false);
+  expect(document.getElementById('safe-mode-toggle').checked).toBe(false);
+});
+
+test('safe mode restored after exiting Zen mode when initially on', () => {
+  State.setSafeMode(true);
+  UI.startZenLevel(1);
+  jest.runAllTimers();
+  expect(State.safeMode).toBe(true);
+  expect(State.previousSafeMode).toBe(true);
+
+  UI.resetToMainScreen();
+  expect(State.safeMode).toBe(true);
+  expect(document.getElementById('safe-mode-toggle').checked).toBe(true);
+});


### PR DESCRIPTION
## Summary
- track the player's previous safe-mode preference in state
- remember that preference when entering Zen mode and restore it after
- keep the safe-mode toggle in sync when leaving Zen mode
- cover Zen mode safe-mode restoration with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68401569c0e08332a51a774fd5ad88c3